### PR TITLE
CI: signed/notarized macOS release automation

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build-macos-release:
     runs-on: macos-latest
+    env:
+      KEYCHAIN_NAME: build.keychain-db
+      KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
 
     steps:
       - name: Checkout
@@ -24,26 +27,86 @@ jobs:
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
 
-      - name: Install dashboard dependencies
-        run: npm ci
-        working-directory: dashboard
+      - name: Resolve version from tag
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(tr -d '[:space:]' < VERSION)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
 
-      - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Import Developer ID certificates
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_P12="$RUNNER_TEMP/app-cert.p12"
+          INSTALLER_P12="$RUNNER_TEMP/installer-cert.p12"
 
-      - name: Build MIDI server binary
-        run: cmake --build build --config Release
+          decode_base64() {
+            local output="$1"
+            if echo "$2" | base64 --decode > "$output" 2>/dev/null; then
+              return 0
+            fi
+            echo "$2" | base64 -D > "$output"
+          }
 
-      - name: Build Electron macOS artifacts
-        run: npm run build:mac
-        working-directory: dashboard
+          decode_base64 "$APP_P12" "$MACOS_APP_CERT_P12_BASE64"
+          decode_base64 "$INSTALLER_P12" "$MACOS_INSTALLER_CERT_P12_BASE64"
 
-      - name: Verify update artifacts
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_NAME"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security list-keychains -d user -s "$KEYCHAIN_NAME" login.keychain-db
+          security default-keychain -s "$KEYCHAIN_NAME"
+
+          security import "$APP_P12" \
+            -k "$KEYCHAIN_NAME" \
+            -P "$MACOS_APP_CERT_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          security import "$INSTALLER_P12" \
+            -k "$KEYCHAIN_NAME" \
+            -P "$MACOS_INSTALLER_CERT_P12_PASSWORD" \
+            -T /usr/bin/productsign \
+            -T /usr/bin/pkgbuild \
+            -T /usr/bin/security
+
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_NAME"
+
+          security find-identity -v
+        env:
+          MACOS_APP_CERT_P12_BASE64: ${{ secrets.MACOS_APP_CERT_P12_BASE64 }}
+          MACOS_APP_CERT_P12_PASSWORD: ${{ secrets.MACOS_APP_CERT_P12_PASSWORD }}
+          MACOS_INSTALLER_CERT_P12_BASE64: ${{ secrets.MACOS_INSTALLER_CERT_P12_BASE64 }}
+          MACOS_INSTALLER_CERT_P12_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_P12_PASSWORD }}
+
+      - name: Build signed and notarized release artifacts
+        run: ./packaging/macos/release-build.sh --version "${{ steps.version.outputs.version }}"
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          DEVELOPER_ID_APP: ${{ secrets.DEVELOPER_ID_APP }}
+          DEVELOPER_ID_INSTALLER: ${{ secrets.DEVELOPER_ID_INSTALLER }}
+          CSC_NAME: ${{ secrets.CSC_NAME }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Verify release artifacts
         run: |
           ls -la dashboard/dist
           test -n "$(find dashboard/dist -name 'latest-mac*.yml' -type f | head -1)"
-          test -n "$(find dashboard/dist -name '*-mac.zip' -type f | head -1)"
-          test -n "$(find dashboard/dist -name '*.dmg' -type f | head -1)"
+          test -n "$(find dashboard/dist -name '*-${{ steps.version.outputs.version }}*-mac.zip' -type f | head -1)"
+          test -n "$(find dashboard/dist -name '*-${{ steps.version.outputs.version }}*.dmg' -type f | head -1)"
+          test -f "build/pkg/MidiServer-${{ steps.version.outputs.version }}.pkg"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -54,6 +117,7 @@ jobs:
             dashboard/dist/*.zip
             dashboard/dist/*.blockmap
             dashboard/dist/latest-mac*.yml
+            build/pkg/MidiServer-*.pkg
 
       - name: Publish GitHub release assets
         if: startsWith(github.ref, 'refs/tags/')
@@ -64,3 +128,4 @@ jobs:
             dashboard/dist/*.zip
             dashboard/dist/*.blockmap
             dashboard/dist/latest-mac*.yml
+            build/pkg/MidiServer-*.pkg

--- a/docs/1.0/self-update/release-runbook.md
+++ b/docs/1.0/self-update/release-runbook.md
@@ -103,3 +103,22 @@ If you only need a `.pkg` installer and no release publication:
   - `*.dmg` (if generated)
 - Installer in `build/pkg/`
   - `MidiServer-<version>.pkg`
+
+## CI Release Secrets
+
+The GitHub Actions workflow `.github/workflows/release-macos.yml` requires:
+
+- `MACOS_KEYCHAIN_PASSWORD`
+- `MACOS_APP_CERT_P12_BASE64`
+- `MACOS_APP_CERT_P12_PASSWORD`
+- `MACOS_INSTALLER_CERT_P12_BASE64`
+- `MACOS_INSTALLER_CERT_P12_PASSWORD`
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+
+Optional overrides (otherwise defaults from `release.config.sh` are used):
+
+- `DEVELOPER_ID_APP`
+- `DEVELOPER_ID_INSTALLER`
+- `CSC_NAME`


### PR DESCRIPTION
## Summary
- update macOS release workflow to import Developer ID certs from GitHub secrets
- run scripted release build () in CI with signing + notarization
- publish updater artifacts and installer pkg from CI release job
- document required CI secrets in release runbook

## Issues
- closes #10
- closes #11
