### PR TITLE
Fix CI macOS signing entitlements path

### DIFF
--- a/dashboard/electron-builder.yml
+++ b/dashboard/electron-builder.yml
@@ -35,7 +35,7 @@ mac:
       arch:
         - arm64
         - x64
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlementsInherit: ../packaging/macos/entitlements.plist
   extendInfo:
     NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.

--- a/packaging/macos/build-installer.sh
+++ b/packaging/macos/build-installer.sh
@@ -276,7 +276,7 @@ if [ "$SKIP_SIGN" = false ]; then
     echo "Signing app bundle..."
     codesign --sign "$DEVELOPER_ID_APP" \
         --options runtime \
-        --entitlements "$DASHBOARD_DIR/build/entitlements.mac.plist" \
+        --entitlements "$SCRIPT_DIR/entitlements.plist" \
         --timestamp \
         --force \
         --deep \


### PR DESCRIPTION
Fixes Release macOS workflow failure on v0.1.10 by using a tracked entitlements path for both electron-builder and installer codesign steps.

- update dashboard/electron-builder.yml entitlements path to ../packaging/macos/entitlements.plist
- update packaging/macos/build-installer.sh app signing entitlements path to packaging/macos/entitlements.plist
