### PR TITLE
fix(release): enforce build/notarization timeouts

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build-macos-release:
     runs-on: macos-latest
+    timeout-minutes: 90
     env:
       KEYCHAIN_NAME: build.keychain-db
       KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
@@ -93,6 +94,7 @@ jobs:
           MACOS_INSTALLER_CERT_P12_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_P12_PASSWORD }}
 
       - name: Build signed and notarized release artifacts
+        timeout-minutes: 45
         run: ./packaging/macos/release-build.sh --version "${{ steps.version.outputs.version }}"
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/packaging/macos/build-installer.sh
+++ b/packaging/macos/build-installer.sh
@@ -40,6 +40,7 @@ DEVELOPER_ID_INSTALLER="${DEVELOPER_ID_INSTALLER:-}"
 APPLE_ID="${APPLE_ID:-}"
 APPLE_TEAM_ID="${APPLE_TEAM_ID:-}"
 APPLE_APP_SPECIFIC_PASSWORD="${APPLE_APP_SPECIFIC_PASSWORD:-}"
+NOTARY_WAIT_TIMEOUT="${NOTARY_WAIT_TIMEOUT:-20m}"
 CSC_NAME="${CSC_NAME:-}"
 CSC_IDENTITY_AUTO_DISCOVERY="${CSC_IDENTITY_AUTO_DISCOVERY:-}"
 
@@ -90,6 +91,7 @@ Environment variables:
     APPLE_ID                      Apple ID for notarization
     APPLE_TEAM_ID                 Team ID for notarization
     APPLE_APP_SPECIFIC_PASSWORD   App-specific password for notarization
+    NOTARY_WAIT_TIMEOUT           Timeout for notarytool --wait (default: 20m)
     
 Defaults are loaded from packaging/macos/release.config.sh when present.
 Encrypted notarization secrets are loaded from ~/.config/audiocontrol.org/midi-server/release.secrets.enc
@@ -402,6 +404,7 @@ if [ "$SKIP_SIGN" = false ] && [ "$SKIP_NOTARIZE" = false ]; then
             --apple-id "$APPLE_ID" \
             --team-id "$APPLE_TEAM_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --timeout "$NOTARY_WAIT_TIMEOUT" \
             --wait
 
         echo "Stapling notarization ticket..."


### PR DESCRIPTION
## Summary\n- add workflow timeouts for release job and build step\n- add NOTARY_WAIT_TIMEOUT (default 20m) to build-installer notary submit\n- prevent indefinite hangs in notary/build stages\n\n## Validation\n- ./packaging/macos/release-preflight.sh --skip-install --skip-typecheck\n