### PR TITLE
ci(signing): add installer signing smoke-test workflow

### DIFF
--- a/.github/workflows/installer-sign-smoke.yml
+++ b/.github/workflows/installer-sign-smoke.yml
@@ -1,0 +1,84 @@
+name: Installer Sign Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_timestamp:
+        description: "Enable productsign --timestamp"
+        required: false
+        default: false
+        type: boolean
+      productsign_timeout_seconds:
+        description: "Timeout for productsign"
+        required: false
+        default: "180"
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/installer-sign-smoke.yml'
+      - 'packaging/macos/installer-sign-smoke.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-sign-installer:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    env:
+      KEYCHAIN_NAME: build.keychain-db
+      KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Import Installer certificate
+        shell: bash
+        run: |
+          set -euo pipefail
+          INSTALLER_P12="$RUNNER_TEMP/installer-cert.p12"
+
+          decode_base64() {
+            local output="$1"
+            if echo "$2" | base64 --decode > "$output" 2>/dev/null; then
+              return 0
+            fi
+            echo "$2" | base64 -D > "$output"
+          }
+
+          decode_base64 "$INSTALLER_P12" "$MACOS_INSTALLER_CERT_P12_BASE64"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_NAME"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security list-keychains -d user -s "$KEYCHAIN_NAME" login.keychain-db
+          security default-keychain -s "$KEYCHAIN_NAME"
+
+          security import "$INSTALLER_P12" \
+            -k "$KEYCHAIN_NAME" \
+            -P "$MACOS_INSTALLER_CERT_P12_PASSWORD" \
+            -T /usr/bin/productsign \
+            -T /usr/bin/pkgbuild \
+            -T /usr/bin/security
+
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_NAME"
+
+          security find-identity -v -p basic
+        env:
+          MACOS_INSTALLER_CERT_P12_BASE64: ${{ secrets.MACOS_INSTALLER_CERT_P12_BASE64 }}
+          MACOS_INSTALLER_CERT_P12_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_P12_PASSWORD }}
+
+      - name: Sign dummy installer
+        timeout-minutes: 5
+        run: ./packaging/macos/installer-sign-smoke.sh
+        env:
+          DEVELOPER_ID_INSTALLER: ${{ secrets.DEVELOPER_ID_INSTALLER }}
+          PRODUCTSIGN_TIMEOUT_SECONDS: ${{ inputs.productsign_timeout_seconds || '180' }}
+          PRODUCTSIGN_USE_TIMESTAMP: ${{ inputs.use_timestamp && 'true' || 'false' }}

--- a/docs/1.0/self-update/release-runbook.md
+++ b/docs/1.0/self-update/release-runbook.md
@@ -133,3 +133,18 @@ Optional overrides (otherwise defaults from `release.config.sh` are used):
 
 - `.github/workflows/release-preflight.yml` runs fast checks on PRs/pushes that touch release files.
 - `.github/workflows/release-macos.yml` runs a fail-fast preflight step before certificate import and notarized build steps.
+
+## Fast Sign-Only CI Loop
+
+Use `.github/workflows/installer-sign-smoke.yml` to debug installer signing quickly.
+It does not build app code. It only:
+
+- imports the installer certificate
+- builds a dummy installer payload
+- runs `productsign`
+- verifies signature with `pkgutil --check-signature`
+
+You can run it from GitHub Actions with optional inputs:
+
+- `use_timestamp` (`true`/`false`)
+- `productsign_timeout_seconds` (default `180`)

--- a/packaging/macos/installer-sign-smoke.sh
+++ b/packaging/macos/installer-sign-smoke.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEVELOPER_ID_INSTALLER="${DEVELOPER_ID_INSTALLER:-}"
+PRODUCTSIGN_TIMEOUT_SECONDS="${PRODUCTSIGN_TIMEOUT_SECONDS:-180}"
+PRODUCTSIGN_USE_TIMESTAMP="${PRODUCTSIGN_USE_TIMESTAMP:-false}"
+
+if [ -z "$DEVELOPER_ID_INSTALLER" ]; then
+    echo "Error: DEVELOPER_ID_INSTALLER is required." >&2
+    exit 1
+fi
+
+run_with_timeout() {
+    local timeout_seconds="$1"
+    shift
+    perl -e 'my $t=shift @ARGV; alarm($t); exec @ARGV or die "exec failed: $!";' \
+        "$timeout_seconds" "$@"
+}
+
+WORK_DIR="${RUNNER_TEMP:-/tmp}/installer-sign-smoke"
+PAYLOAD_DIR="$WORK_DIR/payload"
+UNSIGNED_PKG="$WORK_DIR/MidiServerSmoke-unsigned.pkg"
+SIGNED_PKG="$WORK_DIR/MidiServerSmoke-signed.pkg"
+
+echo "==> Preparing smoke-test payload"
+rm -rf "$WORK_DIR"
+mkdir -p "$PAYLOAD_DIR/usr/local/share/midi-server-smoke"
+cat > "$PAYLOAD_DIR/usr/local/share/midi-server-smoke/README.txt" <<EOF
+MIDI Server installer signing smoke test.
+EOF
+
+echo "==> Building unsigned smoke pkg"
+pkgbuild \
+    --root "$PAYLOAD_DIR" \
+    --identifier "org.audiocontrol.midi-server.smoke" \
+    --version "0.0.0" \
+    --install-location "/" \
+    "$UNSIGNED_PKG"
+
+PRODUCTSIGN_ARGS=(
+    --sign "$DEVELOPER_ID_INSTALLER"
+)
+if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
+    PRODUCTSIGN_ARGS+=(--timestamp)
+fi
+PRODUCTSIGN_ARGS+=(
+    "$UNSIGNED_PKG"
+    "$SIGNED_PKG"
+)
+
+echo "==> Running productsign (timeout: ${PRODUCTSIGN_TIMEOUT_SECONDS}s, timestamp: ${PRODUCTSIGN_USE_TIMESTAMP})"
+run_with_timeout "$PRODUCTSIGN_TIMEOUT_SECONDS" productsign "${PRODUCTSIGN_ARGS[@]}"
+
+echo "==> Verifying signed smoke pkg"
+pkgutil --check-signature "$SIGNED_PKG"
+
+echo "==> Smoke test passed"
+ls -lh "$UNSIGNED_PKG" "$SIGNED_PKG"


### PR DESCRIPTION
## Summary\n- add a standalone Installer Sign Smoke workflow for tight CI iteration\n- add packaging/macos/installer-sign-smoke.sh to build/sign/verify a dummy pkg\n- add short, explicit productsign timeout and optional timestamp toggle\n- update runbook with sign-only loop docs\n\n## Scope\nNo app build, no installer packaging flow, no notarization. This only validates installer cert import + productsign path.