### PR TITLE
ci(signing): add app-cert import toggle to smoke workflow

### DIFF
--- a/.github/workflows/installer-sign-smoke.yml
+++ b/.github/workflows/installer-sign-smoke.yml
@@ -3,6 +3,11 @@ name: Installer Sign Smoke
 on:
   workflow_dispatch:
     inputs:
+      import_app_cert:
+        description: "Import Developer ID Application cert too"
+        required: false
+        default: false
+        type: boolean
       use_timestamp:
         description: "Enable productsign --timestamp"
         required: false
@@ -40,6 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           INSTALLER_P12="$RUNNER_TEMP/installer-cert.p12"
+          APP_P12="$RUNNER_TEMP/app-cert.p12"
 
           decode_base64() {
             local output="$1"
@@ -50,6 +56,9 @@ jobs:
           }
 
           decode_base64 "$INSTALLER_P12" "$MACOS_INSTALLER_CERT_P12_BASE64"
+          if [ "$IMPORT_APP_CERT" = true ]; then
+            decode_base64 "$APP_P12" "$MACOS_APP_CERT_P12_BASE64"
+          fi
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
           security set-keychain-settings -lut 3600 "$KEYCHAIN_NAME"
@@ -63,6 +72,13 @@ jobs:
             -T /usr/bin/productsign \
             -T /usr/bin/pkgbuild \
             -T /usr/bin/security
+          if [ "$IMPORT_APP_CERT" = true ]; then
+            security import "$APP_P12" \
+              -k "$KEYCHAIN_NAME" \
+              -P "$MACOS_APP_CERT_P12_PASSWORD" \
+              -T /usr/bin/codesign \
+              -T /usr/bin/security
+          fi
 
           security set-key-partition-list \
             -S apple-tool:,apple: \
@@ -72,6 +88,9 @@ jobs:
 
           security find-identity -v -p basic
         env:
+          IMPORT_APP_CERT: ${{ inputs.import_app_cert && 'true' || 'false' }}
+          MACOS_APP_CERT_P12_BASE64: ${{ secrets.MACOS_APP_CERT_P12_BASE64 }}
+          MACOS_APP_CERT_P12_PASSWORD: ${{ secrets.MACOS_APP_CERT_P12_PASSWORD }}
           MACOS_INSTALLER_CERT_P12_BASE64: ${{ secrets.MACOS_INSTALLER_CERT_P12_BASE64 }}
           MACOS_INSTALLER_CERT_P12_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_P12_PASSWORD }}
 


### PR DESCRIPTION
Adds import_app_cert input to Installer Sign Smoke so we can isolate whether dual-cert keychain import causes productsign hangs.