### PR TITLE
ci(signing): add productbuild toggle to probe

### DIFF
--- a/.github/workflows/installer-package-probe.yml
+++ b/.github/workflows/installer-package-probe.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: "app"
         type: string
+      run_productbuild:
+        description: "Run productbuild before productsign"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -103,3 +108,4 @@ jobs:
           PROBE_SIGN_TARGET: ${{ inputs.sign_target || 'distribution' }}
           PROBE_USE_COMPONENT_PLIST: ${{ inputs.use_component_plist && 'true' || 'false' }}
           PROBE_PAYLOAD_TYPE: ${{ inputs.payload_type || 'app' }}
+          PROBE_RUN_PRODUCTBUILD: ${{ inputs.run_productbuild && 'true' || 'false' }}


### PR DESCRIPTION
Adds run_productbuild input to Installer Package Probe so we can test productsign with and without productbuild in the path.