### PR TITLE
ci(signing): probe productbuild --sign path

### DIFF
--- a/.github/workflows/installer-package-probe.yml
+++ b/.github/workflows/installer-package-probe.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: true
         type: boolean
+      sign_method:
+        description: "Signing method (productsign|productbuild_sign)"
+        required: false
+        default: "productsign"
+        type: string
 
 permissions:
   contents: read
@@ -109,3 +114,4 @@ jobs:
           PROBE_USE_COMPONENT_PLIST: ${{ inputs.use_component_plist && 'true' || 'false' }}
           PROBE_PAYLOAD_TYPE: ${{ inputs.payload_type || 'app' }}
           PROBE_RUN_PRODUCTBUILD: ${{ inputs.run_productbuild && 'true' || 'false' }}
+          PROBE_SIGN_METHOD: ${{ inputs.sign_method || 'productsign' }}


### PR DESCRIPTION
Adds sign_method input to Installer Package Probe so we can test productbuild --sign as an alternative signing path to productsign.