### PR TITLE
fix(signing): enforce --timestamp=none when disabled

### DIFF
--- a/packaging/macos/build-installer.sh
+++ b/packaging/macos/build-installer.sh
@@ -398,6 +398,8 @@ if [ "$SKIP_SIGN" = false ]; then
     )
     if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
         PRODUCTSIGN_ARGS+=(--timestamp)
+    else
+        PRODUCTSIGN_ARGS+=(--timestamp=none)
     fi
     PRODUCTSIGN_ARGS+=(
         "$UNSIGNED_PKG"

--- a/packaging/macos/installer-package-probe.sh
+++ b/packaging/macos/installer-package-probe.sh
@@ -212,6 +212,8 @@ EOF
         )
         if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
             PRODUCTBUILD_ARGS=(--timestamp "${PRODUCTBUILD_ARGS[@]}")
+        else
+            PRODUCTBUILD_ARGS=(--timestamp=none "${PRODUCTBUILD_ARGS[@]}")
         fi
         echo "==> Running productbuild with signing (method: productbuild_sign)"
         run_with_timeout "$PRODUCTSIGN_TIMEOUT_SECONDS" productbuild "${PRODUCTBUILD_ARGS[@]}"
@@ -231,6 +233,8 @@ PRODUCTSIGN_ARGS=(
 )
 if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
     PRODUCTSIGN_ARGS+=(--timestamp)
+else
+    PRODUCTSIGN_ARGS+=(--timestamp=none)
 fi
 PRODUCTSIGN_ARGS+=(
     "$UNSIGNED_PKG"
@@ -243,6 +247,8 @@ if [ "$PROBE_SIGN_TARGET" = "component" ]; then
     )
     if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
         PRODUCTSIGN_ARGS+=(--timestamp)
+    else
+        PRODUCTSIGN_ARGS+=(--timestamp=none)
     fi
     PRODUCTSIGN_ARGS+=(
         "$COMPONENT_PKG"

--- a/packaging/macos/installer-sign-mutation-sweep.sh
+++ b/packaging/macos/installer-sign-mutation-sweep.sh
@@ -32,6 +32,8 @@ sign_pkg() {
     local args=(--sign "$DEVELOPER_ID_INSTALLER")
     if [ "$USE_TIMESTAMP" = true ]; then
         args+=(--timestamp)
+    else
+        args+=(--timestamp=none)
     fi
     args+=("$input_pkg" "$output_pkg")
     run_with_timeout "$SIGN_TIMEOUT_SECONDS" productsign "${args[@]}"

--- a/packaging/macos/installer-sign-smoke.sh
+++ b/packaging/macos/installer-sign-smoke.sh
@@ -43,6 +43,8 @@ PRODUCTSIGN_ARGS=(
 )
 if [ "$PRODUCTSIGN_USE_TIMESTAMP" = true ]; then
     PRODUCTSIGN_ARGS+=(--timestamp)
+else
+    PRODUCTSIGN_ARGS+=(--timestamp=none)
 fi
 PRODUCTSIGN_ARGS+=(
     "$UNSIGNED_PKG"


### PR DESCRIPTION
Ensures productsign/productbuild signing paths explicitly use --timestamp=none when timestamp is disabled, instead of relying on defaults (which still use TSA for Developer ID).