### PR TITLE
feat: SSE-based MIDI monitoring in dashboard

### DIFF
--- a/dashboard/scripts/server.ts
+++ b/dashboard/scripts/server.ts
@@ -92,7 +92,8 @@ async function startServer(
     server: {
       port: forcedApiPort ?? 0, // Let OS assign an available port or use forced port
       strictPort: !!forcedApiPort,
-      host: '0.0.0.0' // Listen on all interfaces for cross-machine discovery
+      host: '0.0.0.0', // Listen on all interfaces for cross-machine discovery
+      allowedHosts: ['orion-m4', 'orion-m4.local']
     }
   })
 

--- a/dashboard/src/api-server/server.ts
+++ b/dashboard/src/api-server/server.ts
@@ -5,6 +5,7 @@ import type { ApiServerConfig, BuildInfo, LogEntry, LogSeverity } from './types'
 import { ProcessManager } from './process-manager'
 import { LogBuffer } from './log-buffer'
 import { proxyToMidiServer } from './midi-proxy'
+import { proxySseStream } from './sse-proxy'
 import { DiscoveryService } from './discovery'
 import { VirtualPortsStorage } from './virtual-ports-storage'
 import { createRoutingHandlers, type RoutingHandlers } from './routing-handlers'
@@ -370,6 +371,25 @@ export class ApiServer {
             )
           }
         }
+      }
+
+      // SSE proxy for real-time MIDI event streams
+      const portEventsMatch = path.match(/^\/api\/port\/([^/]+)\/events$/)
+      if (portEventsMatch && req.method === 'GET') {
+        const portId = portEventsMatch[1]
+        const status = this.processManager.getStatus()
+        if (!status.running || !status.port) {
+          res.statusCode = 503
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify({ error: 'MIDI server not running' }))
+          return
+        }
+
+        return proxySseStream(
+          res,
+          { targetHost: 'localhost', targetPort: status.port },
+          `/port/${portId}/events`
+        )
       }
 
       // Proxy to MIDI server (strip /midi prefix)

--- a/dashboard/src/api-server/sse-proxy.ts
+++ b/dashboard/src/api-server/sse-proxy.ts
@@ -1,0 +1,104 @@
+import * as http from 'http'
+import type { ServerResponse } from 'http'
+
+interface SseProxyConfig {
+  targetHost: string
+  targetPort: number
+}
+
+/**
+ * Proxies an SSE connection from the C++ MIDI server to the browser client.
+ * Opens a streaming GET request to the upstream server and forwards all
+ * SSE frames (event lines, data lines, keepalive comments) verbatim.
+ *
+ * Cleans up the upstream connection when the client disconnects.
+ */
+export function proxySseStream(
+  res: ServerResponse,
+  config: SseProxyConfig,
+  upstreamPath: string
+): void {
+  // Set SSE headers on the client response
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no'
+  })
+
+  const upstreamReq = http.get(
+    {
+      hostname: config.targetHost,
+      port: config.targetPort,
+      path: upstreamPath,
+      headers: {
+        Accept: 'text/event-stream'
+      }
+    },
+    (upstreamRes) => {
+      if (
+        upstreamRes.statusCode !== undefined &&
+        upstreamRes.statusCode !== 200
+      ) {
+        // Upstream returned an error. Write an SSE error event and close.
+        const statusCode = upstreamRes.statusCode
+        res.write(
+          `event: error\ndata: ${JSON.stringify({ error: `Upstream returned HTTP ${statusCode}` })}\n\n`
+        )
+        res.end()
+        upstreamRes.destroy()
+        return
+      }
+
+      // Pipe upstream SSE data directly to the client.
+      // SSE is a text protocol so we forward raw bytes verbatim.
+      upstreamRes.on('data', (chunk: Buffer) => {
+        const ok = res.write(chunk)
+        // If the client buffer is full, pause upstream until it drains
+        if (!ok) {
+          upstreamRes.pause()
+          res.once('drain', () => {
+            upstreamRes.resume()
+          })
+        }
+      })
+
+      upstreamRes.on('end', () => {
+        res.end()
+      })
+
+      upstreamRes.on('error', (err) => {
+        const message = err instanceof Error ? err.message : String(err)
+        res.write(
+          `event: error\ndata: ${JSON.stringify({ error: `Upstream stream error: ${message}` })}\n\n`
+        )
+        res.end()
+      })
+    }
+  )
+
+  upstreamReq.on('error', (err) => {
+    const message = err instanceof Error ? err.message : String(err)
+    // Connection to upstream failed entirely
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          error: 'Bad Gateway',
+          message: `Failed to connect to MIDI server SSE stream: ${message}`
+        })
+      )
+    } else {
+      // Headers already sent as SSE, write an error event
+      res.write(
+        `event: error\ndata: ${JSON.stringify({ error: `Upstream connection error: ${message}` })}\n\n`
+      )
+      res.end()
+    }
+  })
+
+  // Clean up upstream connection when the client disconnects
+  res.on('close', () => {
+    upstreamReq.destroy()
+  })
+}

--- a/dashboard/src/renderer/src/components/Dashboard.tsx
+++ b/dashboard/src/renderer/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import { AddRouteModal } from '@/components/AddRouteModal'
 import { AddVirtualPortModal } from '@/components/AddVirtualPortModal'
 import { ServerTabs } from '@/components/ServerTabs'
 import { RemoteServerControl } from '@/components/RemoteServerControl'
+import { MidiMonitor } from '@/components/MidiMonitor'
 import { AppShell, PageHeader, ServerStatus, ServerActions, type TabId } from '@/components/layout'
 import '@/styles/layout.css'
 import {
@@ -723,6 +724,19 @@ export function Dashboard(): React.JSX.Element {
                 onDeleteRoute={handleDeleteRoute}
                 onToggleRoute={handleToggleRoute}
               />
+            </div>
+          </>
+        )
+
+      case 'monitor':
+        return (
+          <>
+            <PageHeader
+              title="MIDI Monitor"
+              subtitle="Real-time multi-port message stream"
+            />
+            <div className="page-content-fill">
+              <MidiMonitor inputPorts={localPorts.inputs} />
             </div>
           </>
         )

--- a/dashboard/src/renderer/src/components/MidiMonitor.tsx
+++ b/dashboard/src/renderer/src/components/MidiMonitor.tsx
@@ -1,0 +1,316 @@
+/**
+ * MidiMonitor component.
+ *
+ * Displays a unified, real-time stream of MIDI messages from multiple
+ * input ports. Supports filtering by message type and port, auto-scrolling,
+ * and per-port connection status indicators.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useMidiMessages, midiMessageStore } from '@/stores/midi-message-store'
+import type { StoredMidiMessage } from '@/stores/midi-message-store'
+import { useMidiStream } from '@/hooks/useMidiStream'
+import type { PortSubscription, PortConnectionStatus } from '@/hooks/useMidiStream'
+import {
+  formatMidiMessage,
+  formatTimestamp,
+  classifyMidiMessage,
+  type MidiMessageType
+} from '@/utils/midi-format'
+import type { MidiPort } from '@/types/api'
+
+interface MidiMonitorProps {
+  /** All available input ports (physical + virtual) */
+  inputPorts: ReadonlyArray<MidiPort>
+}
+
+const MESSAGE_TYPE_LABELS: ReadonlyArray<{ value: MidiMessageType; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'note', label: 'Note' },
+  { value: 'cc', label: 'CC' },
+  { value: 'sysex', label: 'SysEx' },
+  { value: 'system', label: 'System' },
+  { value: 'other', label: 'Other' }
+]
+
+/**
+ * Deterministic color assignment for port labels based on port index.
+ */
+const PORT_COLORS = [
+  'text-blue-400',
+  'text-green-400',
+  'text-yellow-400',
+  'text-purple-400',
+  'text-pink-400',
+  'text-cyan-400',
+  'text-orange-400',
+  'text-red-400'
+]
+
+function getPortColor(index: number): string {
+  return PORT_COLORS[index % PORT_COLORS.length]
+}
+
+function statusDotClass(status: PortConnectionStatus | undefined): string {
+  switch (status) {
+    case 'connected':
+      return 'bg-green-500'
+    case 'connecting':
+      return 'bg-yellow-500 animate-pulse'
+    case 'error':
+      return 'bg-red-500'
+    default:
+      return 'bg-gray-500'
+  }
+}
+
+/**
+ * Build a stable portId string that matches what the SSE endpoint expects.
+ * Physical ports use numeric IDs; virtual ports use "virtual:<id>".
+ */
+function buildPortId(port: MidiPort): string {
+  if (port.isVirtual) {
+    const raw = String(port.id)
+    return raw.startsWith('virtual:') ? raw : `virtual:${raw}`
+  }
+  return String(port.id)
+}
+
+export function MidiMonitor({ inputPorts }: MidiMonitorProps): React.JSX.Element {
+  // Track which ports the user has selected for monitoring
+  const [selectedPortIds, setSelectedPortIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [typeFilter, setTypeFilter] = useState<MidiMessageType>('all')
+  const [autoScroll, setAutoScroll] = useState(true)
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const scrollBottomRef = useRef<HTMLDivElement>(null)
+
+  // Build SSE subscriptions for selected ports
+  const subscriptions: ReadonlyArray<PortSubscription> = useMemo(() => {
+    return inputPorts
+      .filter((port) => selectedPortIds.has(buildPortId(port)))
+      .map((port) => ({
+        portId: buildPortId(port),
+        portName: port.name
+      }))
+  }, [inputPorts, selectedPortIds])
+
+  const { getPortStatus } = useMidiStream(subscriptions)
+
+  // All messages from the centralized store
+  const allMessages = useMidiMessages()
+
+  // Build a portId->index map for color assignment (stable ordering from inputPorts)
+  const portColorMap = useMemo(() => {
+    const map = new Map<string, number>()
+    inputPorts.forEach((port, index) => {
+      map.set(buildPortId(port), index)
+    })
+    return map
+  }, [inputPorts])
+
+  // Filter messages to only selected ports and matching type
+  const filteredMessages: ReadonlyArray<StoredMidiMessage> = useMemo(() => {
+    return allMessages.filter((msg) => {
+      if (!selectedPortIds.has(msg.portId)) return false
+      if (typeFilter === 'all') return true
+      return classifyMidiMessage(msg.data) === typeFilter
+    })
+  }, [allMessages, selectedPortIds, typeFilter])
+
+  // Auto-scroll when new messages arrive
+  useEffect(() => {
+    if (autoScroll && scrollBottomRef.current) {
+      scrollBottomRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [filteredMessages, autoScroll])
+
+  // Detect when user scrolls away from the bottom
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 40
+    setAutoScroll(isAtBottom)
+  }, [])
+
+  const togglePort = useCallback((portId: string) => {
+    setSelectedPortIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(portId)) {
+        next.delete(portId)
+      } else {
+        next.add(portId)
+      }
+      return next
+    })
+  }, [])
+
+  const selectAllPorts = useCallback(() => {
+    setSelectedPortIds(new Set(inputPorts.map((p) => buildPortId(p))))
+  }, [inputPorts])
+
+  const deselectAllPorts = useCallback(() => {
+    setSelectedPortIds(new Set())
+  }, [])
+
+  const handleClear = useCallback(() => {
+    midiMessageStore.clear()
+  }, [])
+
+  const allSelected = inputPorts.length > 0 && selectedPortIds.size === inputPorts.length
+
+  return (
+    <div className="flex flex-col h-full gap-4">
+      {/* Controls bar */}
+      <div className="flex flex-wrap items-start gap-4">
+        {/* Port selector */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <h4 className="text-sm font-medium text-gray-300">Input Ports</h4>
+            <button
+              onClick={allSelected ? deselectAllPorts : selectAllPorts}
+              className="text-xs text-blue-400 hover:text-blue-300"
+            >
+              {allSelected ? 'Deselect All' : 'Select All'}
+            </button>
+          </div>
+          {inputPorts.length === 0 ? (
+            <p className="text-xs text-gray-500">No input ports available</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {inputPorts.map((port) => {
+                const portId = buildPortId(port)
+                const isSelected = selectedPortIds.has(portId)
+                const colorIndex = portColorMap.get(portId) ?? 0
+                const status = getPortStatus(portId)
+
+                return (
+                  <button
+                    key={portId}
+                    onClick={() => togglePort(portId)}
+                    className={`
+                      flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-mono
+                      border transition-colors
+                      ${
+                        isSelected
+                          ? 'border-gray-500 bg-gray-700 text-gray-200'
+                          : 'border-gray-700 bg-gray-800 text-gray-500 hover:border-gray-600'
+                      }
+                    `}
+                  >
+                    {isSelected && (
+                      <span
+                        className={`inline-block w-2 h-2 rounded-full ${statusDotClass(status)}`}
+                      />
+                    )}
+                    <span className={isSelected ? getPortColor(colorIndex) : ''}>{port.name}</span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Type filter */}
+        <div>
+          <h4 className="text-sm font-medium text-gray-300 mb-2">Message Type</h4>
+          <div className="flex flex-wrap gap-1">
+            {MESSAGE_TYPE_LABELS.map((item) => (
+              <button
+                key={item.value}
+                onClick={() => setTypeFilter(item.value)}
+                className={`
+                  px-2 py-1 rounded text-xs transition-colors
+                  ${
+                    typeFilter === item.value
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
+                  }
+                `}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col items-end gap-2">
+          <button
+            onClick={handleClear}
+            className="px-3 py-1 rounded text-xs bg-gray-700 text-gray-300 hover:bg-gray-600 transition-colors"
+          >
+            Clear
+          </button>
+          <span className="text-xs text-gray-500">
+            {filteredMessages.length} message{filteredMessages.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Message stream */}
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 min-h-0 bg-gray-900 rounded-lg border border-gray-700 overflow-y-auto font-mono text-xs"
+      >
+        {filteredMessages.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-gray-500">
+              {selectedPortIds.size === 0
+                ? 'Select one or more input ports to begin monitoring'
+                : 'Waiting for MIDI messages...'}
+            </p>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead className="sticky top-0 bg-gray-900 border-b border-gray-700">
+              <tr className="text-gray-500 text-left">
+                <th className="px-3 py-1.5 w-28">Time</th>
+                <th className="px-3 py-1.5 w-48">Port</th>
+                <th className="px-3 py-1.5">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredMessages.map((msg, index) => {
+                const colorIndex = portColorMap.get(msg.portId) ?? 0
+                return (
+                  <tr
+                    key={`${msg.portId}-${msg.timestamp}-${index}`}
+                    className="border-b border-gray-800 hover:bg-gray-800/50"
+                  >
+                    <td className="px-3 py-1 text-gray-500 whitespace-nowrap">
+                      {formatTimestamp(msg.timestamp)}
+                    </td>
+                    <td
+                      className={`px-3 py-1 whitespace-nowrap truncate max-w-[12rem] ${getPortColor(colorIndex)}`}
+                      title={msg.portName}
+                    >
+                      {msg.portName}
+                    </td>
+                    <td className="px-3 py-1 text-gray-300">{formatMidiMessage(msg.data)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+        <div ref={scrollBottomRef} />
+      </div>
+
+      {/* Auto-scroll indicator */}
+      {!autoScroll && filteredMessages.length > 0 && (
+        <button
+          onClick={() => {
+            setAutoScroll(true)
+            scrollBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+          }}
+          className="fixed bottom-6 right-6 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded-full shadow-lg transition-colors"
+        >
+          Scroll to latest
+        </button>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/renderer/src/components/PortDetail.tsx
+++ b/dashboard/src/renderer/src/components/PortDetail.tsx
@@ -1,56 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { OpenPort, MidiMessage } from '@/types/api'
 import { createClient } from '@/api/client'
+import { useMidiStream } from '@/hooks/useMidiStream'
+import { usePortMidiMessages } from '@/stores/midi-message-store'
+import { formatMidiMessage, NOTE_NAMES } from '@/utils/midi-format'
 
 interface PortDetailProps {
   port: OpenPort
   onClose: () => void
   onMessagesReceived: (messages: MidiMessage[]) => void
-}
-
-const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
-
-function formatMidiMessage(data: number[]): string {
-  if (data.length === 0) return '(empty)'
-
-  const status = data[0]
-  const channel = (status & 0x0f) + 1
-  const type = status & 0xf0
-
-  if (status === 0xf0) {
-    return `SysEx [${data.length} bytes]`
-  }
-
-  switch (type) {
-    case 0x80: {
-      const note = data[1]
-      const velocity = data[2]
-      const noteName = NOTE_NAMES[note % 12] + Math.floor(note / 12 - 1)
-      return `Note Off ch${channel} ${noteName} vel=${velocity}`
-    }
-    case 0x90: {
-      const note = data[1]
-      const velocity = data[2]
-      const noteName = NOTE_NAMES[note % 12] + Math.floor(note / 12 - 1)
-      return velocity > 0
-        ? `Note On ch${channel} ${noteName} vel=${velocity}`
-        : `Note Off ch${channel} ${noteName}`
-    }
-    case 0xa0:
-      return `Aftertouch ch${channel} note=${data[1]} pressure=${data[2]}`
-    case 0xb0:
-      return `CC ch${channel} cc${data[1]}=${data[2]}`
-    case 0xc0:
-      return `Program ch${channel} prog=${data[1]}`
-    case 0xd0:
-      return `Ch Pressure ch${channel} pressure=${data[1]}`
-    case 0xe0: {
-      const bend = data[1] | (data[2] << 7)
-      return `Pitch Bend ch${channel} value=${bend - 8192}`
-    }
-    default:
-      return `[${data.map((b) => b.toString(16).padStart(2, '0')).join(' ')}]`
-  }
 }
 
 export function PortDetail({
@@ -67,15 +25,24 @@ export function PortDetail({
   const isVirtual = port.portId.startsWith('virtual:')
   const virtualPortId = isVirtual ? port.portId.replace('virtual:', '') : null
 
-  // Poll for messages on input ports
+  // For real input ports: subscribe to SSE stream
+  const isRealInput = port.type === 'input' && !isVirtual
+  const sseSubscriptions = isRealInput
+    ? [{ portId: port.portId, portName: port.name }]
+    : []
+  const { getPortStatus } = useMidiStream(sseSubscriptions)
+  const sseStatus = isRealInput ? getPortStatus(port.portId) : undefined
+
+  // Read messages from the centralized store for real input ports
+  const storeMessages = usePortMidiMessages(port.portId)
+
+  // For virtual input ports: keep polling
   useEffect(() => {
-    if (port.type !== 'input') return
+    if (port.type !== 'input' || !isVirtual || !virtualPortId) return
 
     const pollMessages = async (): Promise<void> => {
       try {
-        const response = isVirtual && virtualPortId
-          ? await clientRef.current.getVirtualMessages(virtualPortId)
-          : await clientRef.current.getMessages(port.portId)
+        const response = await clientRef.current.getVirtualMessages(virtualPortId)
         if (response.messages.length > 0) {
           onMessagesReceived(response.messages)
         }
@@ -84,14 +51,19 @@ export function PortDetail({
       }
     }
 
-    const interval = setInterval(pollMessages, 100) // Poll every 100ms
+    const interval = setInterval(pollMessages, 100)
     return () => clearInterval(interval)
   }, [port.portId, port.type, onMessagesReceived, isVirtual, virtualPortId])
+
+  // Determine which messages to display
+  const displayMessages: ReadonlyArray<{ data: number[]; timestamp: number }> = isRealInput
+    ? storeMessages
+    : port.messages
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [port.messages])
+  }, [displayMessages])
 
   const sendMessage = useCallback(
     async (message: number[]) => {
@@ -221,13 +193,24 @@ export function PortDetail({
       {port.type === 'input' && (
         <div>
           <h4 className="text-sm font-medium mb-2 text-gray-300">
-            Incoming Messages ({port.messages.length})
+            Incoming Messages ({displayMessages.length})
+            {isRealInput && sseStatus && (
+              <span className={`ml-2 text-xs ${
+                sseStatus === 'connected' ? 'text-green-400' :
+                sseStatus === 'connecting' ? 'text-yellow-400' :
+                'text-red-400'
+              }`}>
+                {sseStatus === 'connected' ? '(streaming)' :
+                 sseStatus === 'connecting' ? '(connecting...)' :
+                 '(connection error)'}
+              </span>
+            )}
           </h4>
           <div className="bg-gray-900 rounded p-2 h-48 overflow-y-auto font-mono text-xs">
-            {port.messages.length === 0 ? (
+            {displayMessages.length === 0 ? (
               <p className="text-gray-500">Waiting for MIDI messages...</p>
             ) : (
-              port.messages.map((msg, i) => (
+              displayMessages.map((msg, i) => (
                 <div key={i} className="py-0.5 text-gray-300">
                   <span className="text-gray-500">
                     {new Date(msg.timestamp).toLocaleTimeString()}

--- a/dashboard/src/renderer/src/components/layout/SiteHeader.tsx
+++ b/dashboard/src/renderer/src/components/layout/SiteHeader.tsx
@@ -8,7 +8,7 @@
 import type { ReactNode } from 'react'
 import { AudioControlLogo } from './AudioControlLogo'
 
-type TabId = 'ports' | 'routes' | 'graph'
+type TabId = 'ports' | 'routes' | 'graph' | 'monitor'
 
 interface Tab {
   id: TabId
@@ -18,7 +18,8 @@ interface Tab {
 const tabs: Tab[] = [
   { id: 'ports', label: 'Global' },
   { id: 'routes', label: 'Routes' },
-  { id: 'graph', label: 'Graph' }
+  { id: 'graph', label: 'Graph' },
+  { id: 'monitor', label: 'Monitor' }
 ]
 
 interface SiteHeaderProps {

--- a/dashboard/src/renderer/src/hooks/useMidiStream.ts
+++ b/dashboard/src/renderer/src/hooks/useMidiStream.ts
@@ -1,0 +1,151 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { platform } from '@/platform'
+import { midiMessageStore } from '@/stores/midi-message-store'
+
+export type PortConnectionStatus = 'connecting' | 'connected' | 'error'
+
+export interface PortSubscription {
+  portId: string
+  portName: string
+}
+
+export interface UseMidiStreamResult {
+  connectionStatuses: ReadonlyMap<string, PortConnectionStatus>
+  getPortStatus: (portId: string) => PortConnectionStatus | undefined
+}
+
+interface MidiEventData {
+  bytes: number[]
+  timestamp: number
+}
+
+function parseMidiEventData(raw: string): MidiEventData {
+  const parsed: unknown = JSON.parse(raw)
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('bytes' in parsed) ||
+    !('timestamp' in parsed)
+  ) {
+    throw new Error(`Invalid MIDI event data: missing 'bytes' or 'timestamp' fields`)
+  }
+
+  const obj = parsed as Record<string, unknown>
+
+  if (!Array.isArray(obj.bytes)) {
+    throw new Error(`Invalid MIDI event data: 'bytes' is not an array`)
+  }
+
+  if (typeof obj.timestamp !== 'number') {
+    throw new Error(`Invalid MIDI event data: 'timestamp' is not a number`)
+  }
+
+  return {
+    bytes: obj.bytes as number[],
+    timestamp: obj.timestamp as number,
+  }
+}
+
+/**
+ * Creates a stable string key from the subscriptions array for use in
+ * dependency comparisons. Sorted to ensure order-independence.
+ */
+function subscriptionsKey(subscriptions: ReadonlyArray<PortSubscription>): string {
+  return subscriptions
+    .map((s) => `${s.portId}:${s.portName}`)
+    .sort()
+    .join('|')
+}
+
+/**
+ * React hook that opens EventSource connections to the SSE proxy for each
+ * subscribed MIDI port and pushes incoming messages into the centralized
+ * midi-message-store.
+ *
+ * Connections are automatically cleaned up on unmount or when the
+ * subscriptions list changes.
+ */
+export function useMidiStream(
+  subscriptions: ReadonlyArray<PortSubscription>
+): UseMidiStreamResult {
+  const [statusMap, setStatusMap] = useState<ReadonlyMap<string, PortConnectionStatus>>(
+    () => new Map()
+  )
+
+  // Use a ref for subscriptions to avoid stale closures in EventSource callbacks,
+  // while still using the key for the effect dependency.
+  const subscriptionsRef = useRef(subscriptions)
+  subscriptionsRef.current = subscriptions
+
+  const key = subscriptionsKey(subscriptions)
+
+  useEffect(() => {
+    const currentSubscriptions = subscriptionsRef.current
+    if (currentSubscriptions.length === 0) {
+      setStatusMap(new Map())
+      return
+    }
+
+    const eventSources = new Map<string, EventSource>()
+    const nextStatuses = new Map<string, PortConnectionStatus>()
+
+    // Initialize all ports as 'connecting'
+    for (const sub of currentSubscriptions) {
+      nextStatuses.set(sub.portId, 'connecting')
+    }
+    setStatusMap(new Map(nextStatuses))
+
+    function updateStatus(portId: string, status: PortConnectionStatus): void {
+      setStatusMap((prev) => {
+        const next = new Map(prev)
+        next.set(portId, status)
+        return next
+      })
+    }
+
+    for (const sub of currentSubscriptions) {
+      const url = `${platform.apiBaseUrl}/api/port/${sub.portId}/events`
+      const es = new EventSource(url)
+      eventSources.set(sub.portId, es)
+
+      es.addEventListener('midi', (event: MessageEvent<string>) => {
+        try {
+          const data = parseMidiEventData(event.data)
+          midiMessageStore.addMessage(sub.portId, sub.portName, data.bytes, data.timestamp)
+        } catch (err) {
+          console.error(`[useMidiStream] Failed to parse MIDI event for port ${sub.portId}:`, err)
+        }
+      })
+
+      es.onopen = (): void => {
+        updateStatus(sub.portId, 'connected')
+      }
+
+      es.onerror = (): void => {
+        // EventSource automatically reconnects on error. We mark the port
+        // as 'error' so the UI can reflect the transient disconnection.
+        // When the connection re-establishes, 'onopen' fires again.
+        updateStatus(sub.portId, 'error')
+      }
+    }
+
+    return (): void => {
+      for (const es of eventSources.values()) {
+        es.close()
+      }
+      eventSources.clear()
+    }
+  }, [key])
+
+  const getPortStatus = useCallback(
+    (portId: string): PortConnectionStatus | undefined => {
+      return statusMap.get(portId)
+    },
+    [statusMap]
+  )
+
+  return {
+    connectionStatuses: statusMap,
+    getPortStatus,
+  }
+}

--- a/dashboard/src/renderer/src/stores/midi-message-store.ts
+++ b/dashboard/src/renderer/src/stores/midi-message-store.ts
@@ -1,0 +1,205 @@
+/**
+ * Centralized MIDI message store.
+ * Messages are stored per-port in memory, independent of component lifecycle.
+ * This ensures messages persist when switching tabs or closing/reopening port views.
+ */
+
+import { useSyncExternalStore, useCallback } from 'react'
+
+export interface StoredMidiMessage {
+  data: number[]
+  timestamp: number
+  portId: string
+  portName: string
+}
+
+interface PortMessageBuffer {
+  messages: StoredMidiMessage[]
+  portName: string
+}
+
+type StoreListener = () => void
+
+interface MidiMessageStoreConfig {
+  maxHistoryPerPort: number
+}
+
+const DEFAULT_CONFIG: MidiMessageStoreConfig = {
+  maxHistoryPerPort: 1000,
+}
+
+interface MidiMessageStore {
+  addMessage(portId: string, portName: string, data: number[], timestamp: number): void
+  addMessages(
+    portId: string,
+    portName: string,
+    messages: ReadonlyArray<{ data: number[]; timestamp: number }>
+  ): void
+  getMessages(portId?: string): ReadonlyArray<StoredMidiMessage>
+  clear(portId?: string): void
+  subscribe(callback: StoreListener): () => void
+  getSnapshot(): ReadonlyArray<StoredMidiMessage>
+  getPortSnapshot(portId: string): ReadonlyArray<StoredMidiMessage>
+}
+
+export function createMidiMessageStore(
+  config: Partial<MidiMessageStoreConfig> = {}
+): MidiMessageStore {
+  const resolvedConfig: MidiMessageStoreConfig = { ...DEFAULT_CONFIG, ...config }
+  const portBuffers = new Map<string, PortMessageBuffer>()
+  const listeners = new Set<StoreListener>()
+
+  // Snapshot caches for useSyncExternalStore compatibility
+  let allMessagesSnapshot: ReadonlyArray<StoredMidiMessage> = []
+  const portSnapshots = new Map<string, ReadonlyArray<StoredMidiMessage>>()
+
+  function notifyListeners(): void {
+    // Invalidate the all-messages snapshot
+    allMessagesSnapshot = buildAllMessagesSnapshot()
+    // Invalidate per-port snapshots
+    portSnapshots.clear()
+
+    for (const listener of listeners) {
+      try {
+        listener()
+      } catch (err) {
+        console.error('[MidiMessageStore] Listener error:', err)
+      }
+    }
+  }
+
+  function buildAllMessagesSnapshot(): ReadonlyArray<StoredMidiMessage> {
+    const all: StoredMidiMessage[] = []
+    for (const buffer of portBuffers.values()) {
+      all.push(...buffer.messages)
+    }
+    all.sort((a, b) => a.timestamp - b.timestamp)
+    return all
+  }
+
+  function getOrCreateBuffer(portId: string, portName: string): PortMessageBuffer {
+    let buffer = portBuffers.get(portId)
+    if (!buffer) {
+      buffer = { messages: [], portName }
+      portBuffers.set(portId, buffer)
+    } else {
+      // Update port name in case it changed
+      buffer.portName = portName
+    }
+    return buffer
+  }
+
+  function pruneBuffer(buffer: PortMessageBuffer): void {
+    if (buffer.messages.length > resolvedConfig.maxHistoryPerPort) {
+      const excess = buffer.messages.length - resolvedConfig.maxHistoryPerPort
+      buffer.messages.splice(0, excess)
+    }
+  }
+
+  function addMessage(
+    portId: string,
+    portName: string,
+    data: number[],
+    timestamp: number
+  ): void {
+    const buffer = getOrCreateBuffer(portId, portName)
+    buffer.messages.push({ data, timestamp, portId, portName })
+    pruneBuffer(buffer)
+    notifyListeners()
+  }
+
+  function addMessages(
+    portId: string,
+    portName: string,
+    messages: ReadonlyArray<{ data: number[]; timestamp: number }>
+  ): void {
+    if (messages.length === 0) return
+
+    const buffer = getOrCreateBuffer(portId, portName)
+    for (const msg of messages) {
+      buffer.messages.push({
+        data: msg.data,
+        timestamp: msg.timestamp,
+        portId,
+        portName,
+      })
+    }
+    pruneBuffer(buffer)
+    notifyListeners()
+  }
+
+  function getMessages(portId?: string): ReadonlyArray<StoredMidiMessage> {
+    if (portId !== undefined) {
+      const buffer = portBuffers.get(portId)
+      if (!buffer) return []
+      return [...buffer.messages]
+    }
+    return buildAllMessagesSnapshot()
+  }
+
+  function clear(portId?: string): void {
+    if (portId !== undefined) {
+      portBuffers.delete(portId)
+    } else {
+      portBuffers.clear()
+    }
+    notifyListeners()
+  }
+
+  function subscribe(callback: StoreListener): () => void {
+    listeners.add(callback)
+    return () => {
+      listeners.delete(callback)
+    }
+  }
+
+  function getSnapshot(): ReadonlyArray<StoredMidiMessage> {
+    return allMessagesSnapshot
+  }
+
+  function getPortSnapshot(portId: string): ReadonlyArray<StoredMidiMessage> {
+    let snapshot = portSnapshots.get(portId)
+    if (!snapshot) {
+      const buffer = portBuffers.get(portId)
+      snapshot = buffer ? [...buffer.messages] : []
+      portSnapshots.set(portId, snapshot)
+    }
+    return snapshot
+  }
+
+  return {
+    addMessage,
+    addMessages,
+    getMessages,
+    clear,
+    subscribe,
+    getSnapshot,
+    getPortSnapshot,
+  }
+}
+
+// Singleton instance
+export const midiMessageStore = createMidiMessageStore()
+
+// React hook: subscribe to all messages
+export function useMidiMessages(): ReadonlyArray<StoredMidiMessage> {
+  return useSyncExternalStore(
+    midiMessageStore.subscribe,
+    midiMessageStore.getSnapshot
+  )
+}
+
+// React hook: subscribe to messages for a specific port
+export function usePortMidiMessages(portId: string): ReadonlyArray<StoredMidiMessage> {
+  const subscribe = useCallback(
+    (callback: () => void) => midiMessageStore.subscribe(callback),
+    []
+  )
+
+  const getSnapshot = useCallback(
+    () => midiMessageStore.getPortSnapshot(portId),
+    [portId]
+  )
+
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/dashboard/src/renderer/src/utils/midi-format.ts
+++ b/dashboard/src/renderer/src/utils/midi-format.ts
@@ -1,0 +1,86 @@
+/**
+ * MIDI message formatting utilities.
+ * Converts raw MIDI byte arrays into human-readable strings.
+ */
+
+export const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+
+export function formatMidiMessage(data: number[]): string {
+  if (data.length === 0) return '(empty)'
+
+  const status = data[0]
+  const channel = (status & 0x0f) + 1
+  const type = status & 0xf0
+
+  if (status === 0xf0) {
+    return `SysEx [${data.length} bytes]`
+  }
+
+  switch (type) {
+    case 0x80: {
+      const note = data[1]
+      const velocity = data[2]
+      const noteName = NOTE_NAMES[note % 12] + Math.floor(note / 12 - 1)
+      return `Note Off ch${channel} ${noteName} vel=${velocity}`
+    }
+    case 0x90: {
+      const note = data[1]
+      const velocity = data[2]
+      const noteName = NOTE_NAMES[note % 12] + Math.floor(note / 12 - 1)
+      return velocity > 0
+        ? `Note On ch${channel} ${noteName} vel=${velocity}`
+        : `Note Off ch${channel} ${noteName}`
+    }
+    case 0xa0:
+      return `Aftertouch ch${channel} note=${data[1]} pressure=${data[2]}`
+    case 0xb0:
+      return `CC ch${channel} cc${data[1]}=${data[2]}`
+    case 0xc0:
+      return `Program ch${channel} prog=${data[1]}`
+    case 0xd0:
+      return `Ch Pressure ch${channel} pressure=${data[1]}`
+    case 0xe0: {
+      const bend = data[1] | (data[2] << 7)
+      return `Pitch Bend ch${channel} value=${bend - 8192}`
+    }
+    default:
+      return `[${data.map((b) => b.toString(16).padStart(2, '0')).join(' ')}]`
+  }
+}
+
+export type MidiMessageType = 'all' | 'note' | 'cc' | 'sysex' | 'system' | 'other'
+
+/**
+ * Classify a MIDI message by its type for filtering purposes.
+ */
+export function classifyMidiMessage(data: number[]): MidiMessageType {
+  if (data.length === 0) return 'other'
+
+  const status = data[0]
+  const type = status & 0xf0
+
+  if (status === 0xf0) return 'sysex'
+  if (status >= 0xf1) return 'system'
+
+  switch (type) {
+    case 0x80:
+    case 0x90:
+      return 'note'
+    case 0xb0:
+      return 'cc'
+    default:
+      return 'other'
+  }
+}
+
+/**
+ * Format a timestamp as HH:MM:SS.mmm
+ */
+export function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp)
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const seconds = date.getSeconds().toString().padStart(2, '0')
+  const millis = date.getMilliseconds().toString().padStart(3, '0')
+  return `${hours}:${minutes}:${seconds}.${millis}`
+}

--- a/docs/1.0/sse-monitoring/README.md
+++ b/docs/1.0/sse-monitoring/README.md
@@ -1,0 +1,24 @@
+# Feature: SSE MIDI Monitoring
+
+**Status:** Planning
+**Branch:** `feature/sse-events`
+
+## Overview
+
+Add real-time MIDI message monitoring to the dashboard using Server-Sent Events instead of HTTP polling. Includes a dedicated Monitor tab for watching multiple ports simultaneously with filtering.
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [prd.md](./prd.md) | Product requirements |
+| [workplan.md](./workplan.md) | Implementation phases |
+| [implementation-summary.md](./implementation-summary.md) | Post-completion report |
+
+## Progress
+
+- [ ] SSE proxy endpoint in API server
+- [ ] Centralized message store
+- [ ] SSE React hook
+- [ ] Replace polling in PortDetail
+- [ ] Dedicated Monitor tab

--- a/docs/1.0/sse-monitoring/implementation-summary.md
+++ b/docs/1.0/sse-monitoring/implementation-summary.md
@@ -1,0 +1,19 @@
+# SSE MIDI Monitoring - Implementation Summary
+
+**Status:** Not started
+
+## Changes Made
+
+_To be completed after implementation._
+
+## Architecture Decisions
+
+_To be completed after implementation._
+
+## Testing
+
+_To be completed after implementation._
+
+## Known Limitations
+
+_To be completed after implementation._

--- a/docs/1.0/sse-monitoring/prd.md
+++ b/docs/1.0/sse-monitoring/prd.md
@@ -1,0 +1,63 @@
+# Product Requirements: SSE MIDI Monitoring in Dashboard
+
+**Created:** 2026-03-30
+**Status:** Draft
+**Owner:** Orion
+
+## Problem Statement
+
+The MIDI server now supports real-time Server-Sent Events streaming via `GET /port/:id/events`, but the dashboard doesn't use it. The dashboard currently polls `GET /port/:id/messages` every 100ms, which:
+
+- Introduces up to 100ms latency on every message
+- Generates constant HTTP traffic even when no messages are flowing
+- Drains the message queue on each poll, so only one client can consume messages
+- Limits monitoring to a single port at a time, embedded in the port detail view
+- Caps history at 100 messages with no persistence across port close/reopen
+
+Users need a dedicated monitoring experience that shows MIDI traffic in real time across multiple ports with filtering, timestamps, and history.
+
+## User Stories
+
+- As a user debugging a MIDI setup, I want to see messages arriving in real time so I can verify signal flow without latency
+- As a user monitoring multiple devices, I want to watch several input ports simultaneously so I can correlate messages across ports
+- As a user troubleshooting SysEx, I want to filter messages by type so I can isolate the traffic I care about
+- As a user testing a route, I want to see message counts and activity indicators so I can confirm the route is forwarding
+
+## Success Criteria
+
+- [ ] Dashboard uses SSE (`EventSource`) instead of polling for MIDI message display
+- [ ] Dedicated "Monitor" tab shows real-time messages from multiple ports
+- [ ] Messages display with sub-second latency from the server
+- [ ] Messages can be filtered by type (Note, CC, SysEx, etc.) and by port
+- [ ] Message history persists across port selection changes
+- [ ] Idle ports generate no HTTP traffic (SSE keepalive only)
+
+## Scope
+
+### In Scope
+
+- Replace polling with SSE in existing PortDetail component
+- New dedicated Monitor tab/view for multi-port monitoring
+- Message filtering by MIDI message type and port
+- Centralized message store that survives port selection changes
+- SSE connection lifecycle management (connect, reconnect, cleanup)
+- Proxy SSE through the dashboard API server to the C++ server
+
+### Out of Scope
+
+- Message recording/export to file
+- MIDI message editing or replay
+- Latency measurement or statistics
+- Custom display formats or themes
+- Changes to the C++ MIDI server (SSE endpoint already exists)
+
+## Dependencies
+
+- C++ MIDI server SSE endpoint (`GET /port/:id/events`) — already implemented in `feature/sse-events`
+- Dashboard API server — needs SSE proxy endpoint
+- `SseClientManager` in C++ server — already handles multiple concurrent clients
+
+## Open Questions
+
+- [ ] Should the Monitor tab auto-subscribe to all open input ports, or require manual selection?
+- [ ] What is a reasonable maximum message history size before auto-pruning?

--- a/docs/1.0/sse-monitoring/workplan.md
+++ b/docs/1.0/sse-monitoring/workplan.md
@@ -1,0 +1,135 @@
+# SSE MIDI Monitoring - Workplan
+
+**GitHub Milestone:** TBD
+**GitHub Issues:** TBD
+
+## Phases
+
+### Phase 1: SSE Proxy in Dashboard API Server
+
+**Objective:** Proxy SSE streams from the C++ MIDI server through the dashboard's API server so the browser can connect without CORS issues.
+
+**Tasks:**
+- [ ] Add SSE proxy endpoint `GET /api/port/:id/events` in the API server
+- [ ] Forward SSE stream from C++ server's `GET /port/:id/events`
+- [ ] Pass through `event: midi` events and keepalive comments
+- [ ] Handle upstream disconnect with automatic cleanup
+
+**Verification:**
+- `curl -N http://localhost:<dashboard-port>/api/port/<id>/events` streams MIDI events
+- Keepalive comments pass through
+- Closing the client connection cleans up the upstream connection
+
+---
+
+### Phase 2: Message Store
+
+**Objective:** Create a centralized message store that holds MIDI messages independent of component lifecycle.
+
+**Tasks:**
+- [ ] Create `src/renderer/src/stores/midi-message-store.ts`
+- [ ] Store messages per port with configurable max history (e.g., 1000 messages)
+- [ ] Support subscribing to message updates (React-compatible)
+- [ ] Include timestamp and source port ID on each message
+- [ ] Provide clear/filter operations
+
+**Verification:**
+- Messages persist when switching between tabs
+- Old messages are pruned when history limit is reached
+- Multiple components can subscribe to the same store
+
+---
+
+### Phase 3: SSE Hook
+
+**Objective:** Create a React hook that manages EventSource connections to the SSE proxy.
+
+**Tasks:**
+- [ ] Create `src/renderer/src/hooks/useMidiStream.ts`
+- [ ] Manage EventSource lifecycle (open, error, reconnect, close)
+- [ ] Parse `event: midi` data and push to message store
+- [ ] Support connecting to multiple ports simultaneously
+- [ ] Clean up connections on unmount
+
+**Verification:**
+- Hook establishes SSE connection and receives messages
+- Automatic reconnect on connection loss
+- No leaked EventSource connections after unmount
+
+---
+
+### Phase 4: Replace Polling in PortDetail
+
+**Objective:** Swap the 100ms polling interval in PortDetail for the SSE hook.
+
+**Tasks:**
+- [ ] Replace `setInterval` polling in PortDetail with `useMidiStream`
+- [ ] Read messages from the message store instead of the poll response
+- [ ] Remove the `getMessages` polling code path for real ports
+- [ ] Keep polling as fallback for virtual ports if they don't support SSE
+
+**Verification:**
+- PortDetail displays messages in real time via SSE
+- No polling HTTP requests visible in network tab for real ports
+- Existing message formatting (`formatMidiMessage`) still works
+- Virtual ports continue to work
+
+---
+
+### Phase 5: Monitor Tab
+
+**Objective:** Add a dedicated "Monitor" tab that shows real-time MIDI messages from multiple input ports.
+
+**Tasks:**
+- [ ] Add "Monitor" entry to navigation in `SiteHeader.tsx`
+- [ ] Create `src/renderer/src/components/MidiMonitor.tsx`
+- [ ] Show port selector to choose which input ports to monitor
+- [ ] Display unified message stream with port labels and timestamps
+- [ ] Add filter controls for message type (Note, CC, SysEx, System, All)
+- [ ] Add filter by port
+- [ ] Add clear button to reset message history
+- [ ] Auto-scroll with scroll-lock behavior (stop auto-scroll when user scrolls up)
+
+**Verification:**
+- Monitor tab appears in navigation
+- Can subscribe to multiple input ports
+- Messages from different ports are visually distinguished
+- Filters reduce visible messages without losing history
+- Auto-scroll pauses when user scrolls up, resumes at bottom
+
+---
+
+## Dependencies
+
+```
+Phase 1 (SSE Proxy)
+    ↓
+Phase 2 (Message Store)
+    ↓
+Phase 3 (SSE Hook)
+    ↓
+Phase 4 (Replace Polling) ──→ Phase 5 (Monitor Tab)
+```
+
+Phase 4 and Phase 5 can proceed in parallel once Phase 3 is complete.
+
+## Files to Create/Modify
+
+```
+dashboard/
+├── src/
+│   ├── api-server/
+│   │   └── server.ts                          # Modified: add SSE proxy endpoint
+│   └── renderer/src/
+│       ├── stores/
+│       │   └── midi-message-store.ts           # New: centralized message store
+│       ├── hooks/
+│       │   └── useMidiStream.ts                # New: SSE connection hook
+│       ├── components/
+│       │   ├── PortDetail.tsx                  # Modified: replace polling with SSE
+│       │   ├── MidiMonitor.tsx                 # New: multi-port monitor view
+│       │   └── layout/
+│       │       └── SiteHeader.tsx              # Modified: add Monitor nav entry
+│       └── types/
+│           └── api.ts                          # Modified: add SSE message types
+```


### PR DESCRIPTION
## Summary

- Add Server-Sent Events streaming to the dashboard, replacing 100ms polling for real-time MIDI message display
- Add dedicated **Monitor tab** for watching multiple input ports simultaneously with message type filtering
- Add feature planning docs (`docs/1.0/sse-monitoring/`)

## Changes

**API server:**
- SSE proxy endpoint (`GET /api/port/:portId/events`) forwards streams from the C++ server
- Allowed hosts for `orion-m4` dev server access

**Frontend:**
- `midi-message-store.ts` — centralized store with `useSyncExternalStore` hooks, per-port history (1000 max)
- `useMidiStream.ts` — manages EventSource connections with per-port status tracking
- `MidiMonitor.tsx` — multi-port monitor with type filtering (Note/CC/SysEx/System), color-coded ports, auto-scroll with pause/resume
- `PortDetail.tsx` — replaced polling with SSE for real ports (virtual ports still poll)
- `midi-format.ts` — extracted shared MIDI formatting utilities
- Added "Monitor" tab to navigation

## Test plan

- [ ] Open an input port, verify messages appear via SSE (no polling in network tab)
- [ ] Open Monitor tab, select multiple input ports, verify unified stream
- [ ] Filter by message type, verify filtering works without losing history
- [ ] Scroll up in Monitor, verify auto-scroll pauses; scroll to bottom, verify it resumes
- [ ] Disconnect/reconnect MIDI server, verify SSE reconnects automatically
- [ ] Virtual ports still work via polling in PortDetail
- [ ] Verify no TypeScript errors (`tsc --noEmit`)